### PR TITLE
Add support for variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Usage](#usage)
   - [Configurator Type](#configurator-type)
   - [Configurator ConfigValue](#configurator-configvalue)
+    - [Custom Validators](#custom-validators)
 - [Example](#example)
   - [`appConfig.ts`](#appconfigts)
   - [`server.ts`](#serverts)
@@ -57,24 +58,37 @@ The `ConfigValue` of your configurator is what is used by the library to build a
 
 Each `ConfigValue` is an object containing:
 
-| Property   | Type       | Required | Default       | Description                                                                                                                                                            |
-| ---------- | ---------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `env`      | `string`   | `Yes`    |               | The environment variable to read from `process.env`                                                                                                                    |
-| `type`     | `Function` | `No`     | `String(...)` | The function that should be used to convert the `env` variable                                                                                                         |
-| `required` | `boolean`  | `No`     | `false`       | Whether or not this environment variable is required to be set. If this is `true` and the environment variable is not set, `configurator(...)` will `throw` an `Error` |
-| `default`  | `any`      | `No`     |               | The default value to use, if any, should the environment variable not be set                                                                                           |
+| Property    | Type                                | Required | Default       | Description                                                                                                                                                            |
+| ----------- | ----------------------------------- | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `env`       | `string`                            | `Yes`    |               | The environment variable to read from `process.env`                                                                                                                    |
+| `type`      | `Function`                          | `No`     | `String(...)` | The function that should be used to convert the `env` variable                                                                                                         |
+| `required`  | `boolean`                           | `No`     | `false`       | Whether or not this environment variable is required to be set. If this is `true` and the environment variable is not set, `configurator(...)` will `throw` an `Error` |
+| `validator` | `any[]`, ` boolean`, or ` Function` | `No`     | `undefined`   | The validator, if any, to run on the environment variable after it has been read in and converted via `type`.                                                          |
+| `default`   | `any`                               | `No`     |               | The default value to use, if any, should the environment variable not be set                                                                                           |
+
+### Custom Validators
+
+If you need to perform your own validation logic, you can do so by providing a `Function` to the `validator` property. The `Function` will be passed a single parameter, the value of `env` after it has been passed through your `type` function (or `String` by default:
 
 ```typescript
-const myConfigValue = {
+const myCustomValidator = {
   admin: {
     port: {
       env: "ADMIN_PORT",
       type: Number,
       required: false,
+      validator: (val: Number) => {
+        // We don't even want to attempt to bind to ports < 1024, as
+        // they are almost always reserved for the operating system
+        // and require admin privileges to bind to. We can always,
+        // and should always, run a reverse proxy in front of
+        // this service anyway.
+        return val > 1024;
+      }
       default: 3991,
-    },
-  },
-};
+    }
+  }
+}
 ```
 
 # Example

--- a/src/tests/configurator.spec.ts
+++ b/src/tests/configurator.spec.ts
@@ -141,6 +141,85 @@ describe("nested environment variable test", () => {
   });
 });
 
+describe("validator tests", () => {
+  test("omitting validator just returns env value", () => {
+    type OmittedConfig = {
+      reddit: {
+        username: string;
+      };
+    };
+
+    const variables = {
+      reddit: { username: { env: "REDDIT_USERNAME", required: true } },
+    };
+
+    return expect(
+      typeof configurator<OmittedConfig>(variables).reddit.username
+    ).toBe("string");
+  });
+
+  test("Boolean validator", () => {
+    type BooleanConfig = {
+      reddit: { username: string };
+    };
+
+    const variables = {
+      reddit: {
+        username: {
+          env: "REDDIT_USERNAME",
+          required: true,
+          validator: true,
+          type: Boolean,
+        },
+      },
+    };
+
+    return expect(configurator<BooleanConfig>(variables).reddit.username).toBe(
+      true
+    );
+  });
+
+  test("Array validator", () => {
+    type ArrayConfig = {
+      reddit: { username: string };
+    };
+
+    const variables = {
+      reddit: {
+        username: {
+          env: "REDDIT_USERNAME",
+          required: true,
+          validator: ["@kyleratti/configurator", "tucker is a cute dog"],
+        },
+      },
+    };
+
+    return expect(() => {
+      configurator<ArrayConfig>(variables);
+    }).not.toThrowError();
+  });
+
+  test("Function validator", () => {
+    type FunctionConfig = { reddit: { username: string } };
+
+    const variables = {
+      reddit: {
+        username: {
+          env: "REDDIT_USERNAME",
+          required: true,
+          validator: (input: String) => {
+            return input.toLowerCase() === "@kyleratti/configurator";
+          },
+        },
+      },
+    };
+
+    return expect(() => {
+      configurator<FunctionConfig>(variables);
+    }).not.toThrowError();
+  });
+});
+
 describe("combinator", () => {
   test("combine two generic objects", () => {
     type GeneralConfigOne = {


### PR DESCRIPTION
This PR adds support to run validation against environment variables to ensure that not only their type is defined, but that their values are, optionally, an expected value.

Intended use cases:

- File/folder path exists
- Variable is an expected/supported configuration value

Example:

This will validate that the reddit account username, `REDDIT_USERNAME`, is a `String` value and that it ends with `bot`. For our example, we are assuming our test application only supports reddit accounts ending in `bot` so that end users are acutely aware that the account is a bot and not a human.

```typescript
type RedditConfig {
  reddit: {
    username: string;
  }
}

const variables = {
  reddit: {
    username: {
      env: "REDDIT_USERNAME",
      required: true,
      validator: (val: String) => {
        return val.toLowerCase().endsWith("bot");
      }
}
```